### PR TITLE
Add link to NPM source

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -75,9 +75,8 @@
 							</span>
 						</span>
 					</h4>
-					<h7>
-						Package from <b>{{ package.source }}</b>
-					</h7>
+					<h7 ng-if="!packageUrl(package)">Package from <b>{{ package.source }}</b></h7>
+					<h7 ng-if="packageUrl(package)">Package from <a ng-href="{{ packageUrl(package) }}"><b>{{ package.source }}</b></a></h7>
 				</div>
 				<p>{{ package.description }}</p>
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -163,6 +163,17 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	};
 
 	/**
+	 * URLs
+	 **/
+	$scope.packageUrl = function (pkg) {
+		if (pkg.source !== 'npm') {
+			return false;
+		}
+
+		return 'https://www.npmjs.com/package/' + pkg.name;
+	};
+
+	/**
 	 * Badges
 	 **/
 	$scope.genBadgeUrl = function (pkg) {


### PR DESCRIPTION
Closes #20 

----

I attempted to follow the coding style of the project(double-curly brackets instead of `ng-bind`, passing the package to the `$scope` function, string concat, etc.)

Obviously the better solution here would be to actually save the package source in the DB instead of manually constructing the URL with string concat.