### PR TITLE
Share snippets improvement

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -3,3 +3,18 @@
   margin:auto;
 }
 
+.package-share input {
+  display: block;
+  width: 100%;
+  margin: 0 0 15px;
+  padding: 8px;
+  font-family: Menlo, Monaco, Courier, monospace;
+  font-size: 13px;
+  line-height: 1.72222;
+  color: inherit;
+  vertical-align: top;
+  cursor: text;
+  background-color: rgb(255, 255, 255);
+  border: 2px solid rgb(231, 233, 236);
+  border-radius: 6px;
+}

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -1,0 +1,5 @@
+.package-share img {
+  display:block;
+  margin:auto;
+}
+

--- a/app/index.html
+++ b/app/index.html
@@ -118,25 +118,10 @@
 
 				<hr>
 
-				<small>
-					Image:
-				</small>
-				<input readonly ng-value="genBadgeUrl(package)" select-on-click/>
-
-				<small>
-					HTML:
-				</small>
-				<input readonly ng-value="genBadgeHTMLMarkup(package)" select-on-click/>
-
-				<small>
-					Markdown:
-				</small>
-				<input readonly ng-value="genBadgeMarkdownMarkup(package)" select-on-click/>
-
-				<small>
-					Textile:
-				</small>
-				<input readonly ng-value="genBadgeTextileMarkup(package)" select-on-click/>
+				<div ng-repeat="format in shareFormats">
+					<small ng-bind="format.title"></small>
+					<input readonly ng-value="format.markup(package)" select-on-click/>
+				</div>
 			</div>
 		</div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -108,6 +108,8 @@
 
 		<div class="row package-share" ng-if="package">
 			<div class="col-lg-4 col-lg-offset-4 col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3 col-xs-10 col-xs-offset-1">
+				<hr>
+
 				<h5>
 					Share this package
 				</h5>
@@ -115,8 +117,6 @@
 					Use the following snippet to share this package quality:
 				</p>
 				<img ng-src="{{ genBadgeUrl(package) }}"/>
-
-				<hr>
 
 				<div ng-repeat="format in shareFormats">
 					<small ng-bind="format.title"></small>

--- a/app/index.html
+++ b/app/index.html
@@ -127,6 +127,16 @@
 					HTML:
 				</small>
 				<input readonly ng-value="genBadgeHTMLMarkup(package)" select-on-click/>
+
+				<small>
+					Markdown:
+				</small>
+				<input readonly ng-value="genBadgeMarkdownMarkup(package)" select-on-click/>
+
+				<small>
+					Textile:
+				</small>
+				<input readonly ng-value="genBadgeTextileMarkup(package)" select-on-click/>
 			</div>
 		</div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -112,10 +112,16 @@
 					Share this package
 				</h5>
 				<p>
-					Use the following HTML snippet to share this package quality:
+					Use the following snippet to share this package quality:
 				</p>
-				<pre>{{ genBadgeMarkup(package) }}</pre>
 				<img ng-src="{{ genBadgeUrl(package) }}"/>
+
+				<hr>
+
+				<small>
+					HTML:
+				</small>
+				<input readonly ng-value="genBadgeMarkup(package)" select-on-click/>
 			</div>
 		</div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -106,7 +106,7 @@
 			</div>
 		</div>
 
-		<div class="row package-share" ng-if="package">
+		<div class="row package-share" ng-if="package && !package.notfound">
 			<div class="col-lg-4 col-lg-offset-4 col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3 col-xs-10 col-xs-offset-1">
 				<hr>
 

--- a/app/index.html
+++ b/app/index.html
@@ -106,7 +106,7 @@
 			</div>
 		</div>
 
-		<div class="row" ng-if="package">
+		<div class="row package-share" ng-if="package">
 			<div class="col-lg-4 col-lg-offset-4 col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3 col-xs-10 col-xs-offset-1">
 				<h5>
 					Share this package
@@ -115,7 +115,7 @@
 					Use the following HTML snippet to share this package quality:
 				</p>
 				<pre>{{ genBadgeMarkup(package) }}</pre>
-				<img ng-src="{{ genBadgeUrl(package) }}" style="display:block; margin:auto"/>
+				<img ng-src="{{ genBadgeUrl(package) }}"/>
 			</div>
 		</div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -119,9 +119,14 @@
 				<hr>
 
 				<small>
+					Image:
+				</small>
+				<input readonly ng-value="genBadgeUrl(package)" select-on-click/>
+
+				<small>
 					HTML:
 				</small>
-				<input readonly ng-value="genBadgeMarkup(package)" select-on-click/>
+				<input readonly ng-value="genBadgeHTMLMarkup(package)" select-on-click/>
 			</div>
 		</div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -114,7 +114,7 @@
 					Share this package
 				</h5>
 				<p>
-					Use the following snippet to share this package quality:
+					Use the following snippets to share this package quality:
 				</p>
 				<img ng-src="{{ genBadgeUrl(package) }}"/>
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -179,6 +179,7 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	/**
 	 * URLs
 	 **/
+	// TODO: this should be a property on the package
 	$scope.siteUrl = function (pkg) {
 		return 'http://packagequality.com/#?package=' + pkg.name;
 	};
@@ -193,8 +194,9 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	/**
 	 * Badges
 	 **/
+	// TODO: this should probably be generated on the backend and passed down as a property
 	$scope.genBadgeUrl = function (pkg) {
-		return 'http://' + pkg.source + '.packagequality.com/badge/' + pkg.name + '.png';
+		return ['http://', pkg.source, '.packagequality.com/badge/', pkg.name, '.png'].join('');
 	};
 	$scope.shareFormats = [
 		{
@@ -203,17 +205,17 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 		}, {
 			title: 'HTML',
 			markup: function (pkg) {
-				return '<img src="' + $scope.genBadgeUrl(pkg) + '"/>';
+				return ['<img src="', $scope.genBadgeUrl(pkg), '"/>'].join('');
 			}
 		}, {
 			title: 'Markdown',
 			markup: function (pkg) {
-				return '[![Package Quality](' + $scope.genBadgeUrl(pkg) + ')](' + $scope.siteUrl(pkg) + ')';
+				return ['[![Package Quality](', $scope.genBadgeUrl(pkg), ')](', $scope.siteUrl(pkg), ')'].join('');
 			}
 		}, {
 			title: 'Textile',
 			markup: function (pkg) {
-				return '!' + $scope.genBadgeUrl(pkg) + '!:' + $scope.siteUrl(pkg);
+				return ['!', $scope.genBadgeUrl(pkg), '!:', $scope.siteUrl(pkg)].join('');
 			}
 		}
 	];

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -193,7 +193,7 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	$scope.genBadgeUrl = function (pkg) {
 		return 'http://' + pkg.source + '.packagequality.com/badge/' + pkg.name + '.png';
 	};
-	$scope.genBadgeMarkup = function (pkg) {
+	$scope.genBadgeHTMLMarkup = function (pkg) {
 		return '<img src="' + $scope.genBadgeUrl(pkg) + '"/>';
 	};
 }]);

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -179,6 +179,9 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	/**
 	 * URLs
 	 **/
+	$scope.siteUrl = function (pkg) {
+		return 'http://packagequality.com/#?package=' + pkg.name;
+	};
 	$scope.packageUrl = function (pkg) {
 		if (pkg.source !== 'npm') {
 			return false;
@@ -195,5 +198,11 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	};
 	$scope.genBadgeHTMLMarkup = function (pkg) {
 		return '<img src="' + $scope.genBadgeUrl(pkg) + '"/>';
+	};
+	$scope.genBadgeMarkdownMarkup = function (pkg) {
+		return '[![Package Quality](' + $scope.genBadgeUrl(pkg) + ')](' + $scope.siteUrl(pkg) + ')';
+	};
+	$scope.genBadgeTextileMarkup = function (pkg) {
+		return '!' + $scope.genBadgeUrl(pkg) + '!:' + $scope.siteUrl(pkg);
 	};
 }]);

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -73,6 +73,20 @@ app.filter('timeAgo', function () {
 });
 
 /**
+ * Directive for auto selecting text in input fields
+ **/
+app.directive('selectOnClick', function () {
+    return {
+        restrict: 'A',
+        link: function (scope, element, attrs) {
+            element.on('click', function () {
+                this.select();
+            });
+        }
+    };
+});
+
+/**
  * Main controller
  * This handles GUI components for packages search
  **/

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -196,13 +196,25 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	$scope.genBadgeUrl = function (pkg) {
 		return 'http://' + pkg.source + '.packagequality.com/badge/' + pkg.name + '.png';
 	};
-	$scope.genBadgeHTMLMarkup = function (pkg) {
-		return '<img src="' + $scope.genBadgeUrl(pkg) + '"/>';
-	};
-	$scope.genBadgeMarkdownMarkup = function (pkg) {
-		return '[![Package Quality](' + $scope.genBadgeUrl(pkg) + ')](' + $scope.siteUrl(pkg) + ')';
-	};
-	$scope.genBadgeTextileMarkup = function (pkg) {
-		return '!' + $scope.genBadgeUrl(pkg) + '!:' + $scope.siteUrl(pkg);
-	};
+	$scope.shareFormats = [
+		{
+			title: 'Image',
+			markup: $scope.genBadgeUrl
+		}, {
+			title: 'HTML',
+			markup: function (pkg) {
+				return '<img src="' + $scope.genBadgeUrl(pkg) + '"/>';
+			}
+		}, {
+			title: 'Markdown',
+			markup: function (pkg) {
+				return '[![Package Quality](' + $scope.genBadgeUrl(pkg) + ')](' + $scope.siteUrl(pkg) + ')';
+			}
+		}, {
+			title: 'Textile',
+			markup: function (pkg) {
+				return '!' + $scope.genBadgeUrl(pkg) + '!:' + $scope.siteUrl(pkg);
+			}
+		}
+	];
 }]);


### PR DESCRIPTION
Closes #32
----
I originally just wanted to make the share snippet HTML autoselect like seen in the npm sidebar etc.

But then I started adding more formats, and yeah well it took a little overhand.

![screen shot 2015-03-26 at 15 33 55](https://cloud.githubusercontent.com/assets/938453/6842032/c3bc0f5c-d3cd-11e4-8ad9-63ef6e1ce1a0.png)

----

At some point it might be worth looking into adding a select list for all the different formats, like Travis has:
![screen shot 2015-03-26 at 15 36 46](https://cloud.githubusercontent.com/assets/938453/6842048/faf47720-d3cd-11e4-9917-717d66eecbee.png)

