### PR TITLE
fix: url encode pkg name in urls

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -181,14 +181,14 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	 **/
 	// TODO: this should be a property on the package
 	$scope.siteUrl = function (pkg) {
-		return 'https://packagequality.com/#?package=' + pkg.name;
+		return 'https://packagequality.com/#?package=' + encodeURIComponent(pkg.name);
 	};
 	$scope.packageUrl = function (pkg) {
 		if (pkg.source !== 'npm') {
 			return false;
 		}
 
-		return 'https://www.npmjs.com/package/' + pkg.name;
+		return 'https://www.npmjs.com/package/' + encodeURIComponent(pkg.name);
 	};
 
 	/**
@@ -196,10 +196,10 @@ app.controller('MainController', ['$scope', '$location', 'packages', function($s
 	 **/
 	// TODO: this should probably be generated on the backend and passed down as a property
 	$scope.genBadgeUrl = function (pkg) {
-		return ['https://packagequality.com/badge/', pkg.name, '.png'].join('');
+		return ['https://packagequality.com/badge/', encodeURIComponent(pkg.name), '.png'].join('');
 	};
 	$scope.genShieldUrl = function (pkg) {
-		return ['https://packagequality.com/shield/', pkg.name, '.svg'].join('');
+		return ['https://packagequality.com/shield/', encodeURIComponent(pkg.name), '.svg'].join('');
 	};
 	$scope.shareFormats = [
 		{


### PR DESCRIPTION
URI encodes `pkg.name` when constructing the URLs.

Fixes: https://github.com/alexfernandez/package-quality/issues/56

Seems to work when tested locally, although the code points to `packagequality.com`, so you need to update domain to localhost.

Generated links look like:

![Screen Shot 2021-02-13 at 14 04 29](https://user-images.githubusercontent.com/744973/107860325-706c4380-6e04-11eb-9abc-36ace3dde23a.png)
